### PR TITLE
chore: Fix attribute of a method in LocationDAO

### DIFF
--- a/backend/src/main/java/com/wtfru/backend/dao/LocationDAO.java
+++ b/backend/src/main/java/com/wtfru/backend/dao/LocationDAO.java
@@ -15,6 +15,6 @@ public interface LocationDAO {
     public LocationDTO get(String sessionUid);
 
     @Update("update locations set latitude={location.latitude}, longitude=#{location.longitude} " +
-            "where session_uid=#{sessionUid")
-    public boolean update(String sessionUid, LocationDTO location);
+            "where session_uid=#{location.sessionUid")
+    public boolean update(LocationDTO location);
 }


### PR DESCRIPTION
`LocationDAO` attribution 중 String type의 `sessionUid`는 `LocationDTO`의 property에 포함되기 때문에 중복 제거를 위해 제거하였습니다.