### PR TITLE
chore: Relocate resolveToken method from JwtFilter to TokenService

### DIFF
--- a/backend/src/main/java/com/wtfru/backend/jwt/JwtFilter.java
+++ b/backend/src/main/java/com/wtfru/backend/jwt/JwtFilter.java
@@ -17,8 +17,6 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(JwtFilter.class);
 
-    public static final String AUTHORIZATION_HEADER = "Authorization";
-
     private TokenService tokenService;
 
     public JwtFilter(TokenService tokenService) {
@@ -28,7 +26,7 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String jwt = resolveToken(request);
+        String jwt = tokenService.resolveToken(request);
         String requestURI = request.getRequestURI();
 
         if (StringUtils.hasText(jwt) && tokenService.validateToken(jwt)) {
@@ -39,13 +37,5 @@ public class JwtFilter extends OncePerRequestFilter {
             logger.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
         }
         filterChain.doFilter(request, response);
-    }
-
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
-            return bearerToken.substring(7);
-        }
-        return null;
     }
 }

--- a/backend/src/main/java/com/wtfru/backend/service/TokenService.java
+++ b/backend/src/main/java/com/wtfru/backend/service/TokenService.java
@@ -15,8 +15,10 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import javax.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,6 +32,7 @@ public class TokenService implements InitializingBean {
     private final Logger logger = LoggerFactory.getLogger(TokenService.class);
 
     private static final String AUTHORITIES_KEY = "auth";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
 
     private final String secret;
     private final long tokenValidityInMilliseconds;
@@ -105,5 +108,13 @@ public class TokenService implements InitializingBean {
             logger.info("JWT 토큰이 잘못되었습니다.");
         }
         return false;
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Controller에서 `resolveToken` method 활용을 위해 해당 method를 `JwtFilet`에서 `TokenService` 내부 method로 변경하였습니다.