### PR TITLE
chore: Fix querys and attributes in LocationDAO for implementation of controller

### DIFF
--- a/backend/src/main/java/com/wtfru/backend/dao/LocationDAO.java
+++ b/backend/src/main/java/com/wtfru/backend/dao/LocationDAO.java
@@ -1,20 +1,26 @@
 package com.wtfru.backend.dao;
 
-import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.Select;
-import org.apache.ibatis.annotations.Update;
+import org.apache.ibatis.annotations.*;
 import org.springframework.stereotype.Repository;
 import com.wtfru.backend.dto.LocationDTO;
 
 @Repository
 public interface LocationDAO {
-    @Insert("insert into locations values")
-    public LocationDTO post(LocationDTO location);
+    @Results(id = "locationDTO", value = {
+            @Result(property = "locationId", column = "location_id", id = true),
+            @Result(property = "sessionUid", column = "session_uid"),
+            @Result(property = "updatedDate", column = "updated_date")
+    })
 
-    @Select("select from locations where session_uid=#{sessionUid}")
+    @Insert("insert into locations (session_uid, latitude, longitude) " +
+            "values (#{sessionUid}, #{latitude}, #{longitude})")
+    public boolean post(String sessionUid, Double latitude, Double longitude);
+
+    @ResultMap("locationDTO")
+    @Select("select * from locations where session_uid=#{sessionUid}")
     public LocationDTO get(String sessionUid);
 
-    @Update("update locations set latitude={location.latitude}, longitude=#{location.longitude} " +
-            "where session_uid=#{location.sessionUid")
-    public boolean update(LocationDTO location);
+    @Update("update locations set latitude=#{latitude}, longitude=#{longitude} " +
+            "where session_uid=#{sessionUid}")
+    public boolean update(Double latitude, Double longitude, String sessionUid);
 }

--- a/backend/src/main/resources/sql/locations.sql
+++ b/backend/src/main/resources/sql/locations.sql
@@ -1,7 +1,7 @@
 CREATE TABLE locations
 (
- location_id int NOT NULL,
- session_uid uuid default NOT NULL,
+ location_id SERIAL DEFAULT NOT NULL,
+ session_uid varchar(255) NOT NULL,
  latitude    numeric NULL,
  longitude   numeric NULL,
  CONSTRAINT PK_locations PRIMARY KEY ( location_id ),


### PR DESCRIPTION
## Changes in `LocationDAO`
1. `ResultMap` 추가 
2. `post` method attribute type: `LocationDTO location` -> `String sessionUid`, `Double latitude`, `Double longitude` 
3. `update` method attribute type: `LocationDTO location` -> `Double latitude`, `Double longitude`, `String sessionUid`

## Changes in `locations.sql`
1. `location_id` type: `int` -> `SERIAL DEFAULT`
2. `session_uid` type: `uuid DEFAULT` -> `varchar(255)`